### PR TITLE
fix nesting errors in Nokogiri xml_processor

### DIFF
--- a/lib/opensrs/xml_processor/nokogiri.rb
+++ b/lib/opensrs/xml_processor/nokogiri.rb
@@ -17,8 +17,8 @@ module OpenSRS
       body       = ::Nokogiri::XML::Node.new("body", builder.doc)
       data_block = ::Nokogiri::XML::Node.new("data_block", builder.doc)
       other_data = encode_data(data, builder.doc)
-      builder.doc << envelope << header << version << '0.9'
-      envelope << body << data_block << other_data
+      builder.doc << ( envelope << ( header << ( version << '0.9') ) )
+      envelope << ( body << ( data_block << other_data ) )
       return builder.to_xml
     end
 


### PR DESCRIPTION
I do, as you write in the instructions (readme.rdoc)

```
OpenSRS::Server.xml_processor = :nokogiri

server_local = OpenSRS::Server.new(:server   => "http://localhost:3000/opensrs",
                                   :username => "username",
                                   :password => "53cr3t",
                                   :key      => "c633be3170c7fb3fb29e2f99b84be2410" )

  def get_some_action(some_index)
    server_local.call(
      :action => "action_name",
      :object => "object_name",
      :attributes => {
        :some_index => some_index
      }
    )
  end

get_some_action("578").request_xml
```

after this I get XML request like this:

```
<?xml version="1.0"?>
<OPS_envelope>
  <header/>
  <version/>
  0.9
  <body/>
  <data_block/>
  <dt_assoc>
    <item key="protocol">XCP</item>
    <item key="action">action_name</item>
    <item key="object">object_name</item>
    <item key="attributes">
    <dt_assoc>
      <item key="some_index">578</item>
    </dt_assoc>
    </item>
  </dt_assoc>
</OPS_envelope>
```

But in my opinion it must be like this

```
<?xml version="1.0"?>
<OPS_envelope>
  <header>
    <version>0.9</version>
  </header>
  <body>
    <data_block>
      <dt_assoc>
        <item key="protocol">XCP</item>
        <item key="action">action_name</item>
        <item key="object">object_name</item>
        <item key="attributes">
          <dt_assoc>
            <item key="some_index">578</item>
          </dt_assoc>
        </item>
      </dt_assoc>
    </data_block>
  </body>
</OPS_envelope>
```

if I change xml_processor to libxml

```
OpenSRS::Server.xml_processor = :libxml
```

I get correct xml request

```
<?xml version="1.0" encoding="UTF-8"?>
<OPS_envelope>
  <header>
    <version>0.9</version>
  </header>
  <body>
    <data_block>
      <dt_assoc>
        <item key="protocol">XCP</item>
        <item key="action">action_name</item>
        <item key="object">object_name</item>
        <item key="attributes">
          <dt_assoc>
            <item key="some_index">578</item>
          </dt_assoc>
        </item>
      </dt_assoc>
    </data_block>
  </body>
</OPS_envelope>
```
