### PR TITLE
Expose the xml for the last request submitted

### DIFF
--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -91,6 +91,11 @@ describe OpenSRS::Server do
       http.should_receive(:post).and_raise err = Timeout::Error.new('test')
       expect { server.call }.to raise_exception OpenSRS::TimeoutError
     end
+
+    it "makes the request xml of the last request available" do
+      server.call( { :some => 'data' } )
+      server.last_request_xml.should eql xml
+    end
   end
 
   describe "#test xml processor" do


### PR DESCRIPTION
- When an exception (e.g. timeout) is raised, a response object containing
  the request xml is not returned - this is useful when submitting
  support requests to OpenSRS
- I have added it to the Server class, as it doesn't feel like a good fit anywhere else, given that, we don't have a response if something heads south. If you would prefer, I am happy to have it cleared after the request is successful - so that it is only available on an exception being raised?
