### PR TITLE
Use real newlines instead of escaped newlines

### DIFF
--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -79,7 +79,7 @@ module OpenSRS
       message = "[OpenSRS] #{type} XML"
       message = "#{message} for #{options[:object]} #{options[:action]}" if options[:object] && options[:action]
 
-      line = [message, data].join('\n')
+      line = [message, data].join("\n")
       logger.info(line)
     end
 


### PR DESCRIPTION
Using a single-quote puts the text "\n" into the log file instead of a newline. Changing to double-quotes fixes this.
