### PR TITLE
Match subclasses when encoding data

### DIFF
--- a/lib/opensrs/xml_processor.rb
+++ b/lib/opensrs/xml_processor.rb
@@ -16,16 +16,16 @@ module OpenSRS
 
     # Encodes individual elements, and their child elements, for the root XML document.
     def self.encode_data(data, container = nil)
-      case data.class.to_s
-      when "Array" then return encode_dt_array(data, container)
-      when "Hash"  then return encode_dt_assoc(data, container)
-      when "String", "Numeric", "Date", "Time", "Symbol", "NilClass"
-        return data.to_s
+      case data
+      when Array 
+        encode_dt_array(data, container)
+      when Hash  
+        encode_dt_assoc(data, container)
+      when String, Numeric, Date, Time, Symbol, NilClass
+        data.to_s
       else
-        return data.inspect
+        data.inspect
       end
-
-      return nil
     end
 
     def self.encode_dt_array(data, container)

--- a/spec/opensrs/xml_processor/nokogiri_spec.rb
+++ b/spec/opensrs/xml_processor/nokogiri_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 require 'date'
 
+class OrderedHash < Hash
+end
+
 describe OpenSRS::XmlProcessor::Nokogiri do
   describe ".build" do
     it "should create XML for a nested hash" do
@@ -47,6 +50,22 @@ describe OpenSRS::XmlProcessor::Nokogiri do
       it { @e.children[0].name.should eql('item') }
       it { @e.children[0].attributes["key"].value.should eql('name') }
     end
+
+    context "on a hash subclass" do
+      before(:each) do
+        ohash = OrderedHash.new
+        ohash[:name] = 'kitten'
+        @e = OpenSRS::XmlProcessor::Nokogiri.encode_data(ohash, @doc)
+      end
+
+      it { @e.should be_an_instance_of(::Nokogiri::XML::Element) }
+      it { @e.name.should eql('dt_assoc') }
+
+      it { @e.should have(1).children }
+      it { @e.children[0].name.should eql('item') }
+      it { @e.children[0].attributes["key"].value.should eql('name') }
+    end
+
 
     context "on a nested hash" do
       before(:each) do


### PR DESCRIPTION
## Problem

We ran into a problem where we tried to use `HashWithIndifferentAccess` for storing the contact set. However, this fails the conditionals in `XmlProcessor.encode_data`, because that method does an exact match on class name.
## Solution

Use the `===` method from case statements, which checks for `is_a?` status when applied to classes. Then subclasses will match their subclass's case.
