### PR TITLE
remove libxml as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@
 *.so
 *.o
 *.a
+*.gem
 mkmf.log

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,3 @@ DEPENDENCIES
   rake
   rspec
   shoulda
-
-BUNDLED WITH
-   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,11 @@
+PATH
+  remote: .
+  specs:
+    opensrs (0.3.4)
+      libxml-ruby
+
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (4.1.8)
       i18n (~> 0.6, >= 0.6.9)
@@ -7,54 +13,15 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    addressable (2.3.6)
-    builder (3.2.2)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
-    faraday (0.9.0)
-      multipart-post (>= 1.2, < 3)
-    git (1.2.8)
-    github_api (0.12.2)
-      addressable (~> 2.3)
-      descendants_tracker (~> 0.0.4)
-      faraday (~> 0.8, < 0.10)
-      hashie (>= 3.3)
-      multi_json (>= 1.7.5, < 2.0)
-      nokogiri (~> 1.6.3)
-      oauth2
-    hashie (3.3.2)
-    highline (1.6.21)
     i18n (0.6.11)
-    jeweler (2.0.1)
-      builder
-      bundler (>= 1.0)
-      git (>= 1.2.5)
-      github_api
-      highline (>= 1.6.15)
-      nokogiri (>= 1.5.10)
-      rake
-      rdoc
     json (1.8.1)
-    jwt (1.2.0)
     libxml-ruby (2.7.0)
     mini_portile (0.6.1)
     minitest (5.5.0)
-    multi_json (1.10.1)
-    multi_xml (0.5.5)
-    multipart-post (2.0.0)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
-    oauth2 (1.0.0)
-      faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0)
-      multi_json (~> 1.3)
-      multi_xml (~> 0.5)
-      rack (~> 1.2)
-    rack (1.5.2)
     rake (10.4.2)
-    rdoc (4.2.0)
-      json (~> 1.4)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -77,9 +44,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jeweler
-  libxml-ruby
+  bundler (~> 1.7)
   nokogiri
-  rake
+  opensrs!
+  rake (~> 10.0)
   rspec (~> 2.0)
   shoulda

--- a/opensrs.gemspec
+++ b/opensrs.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "libxml-ruby", "~> 0"
+  spec.add_runtime_dependency "libxml-ruby", ">= 0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 2.0"
-  spec.add_development_dependency "shoulda", "~> 0"
-  spec.add_development_dependency "nokogiri", "~> 0"
+  spec.add_development_dependency "shoulda", ">= 0"
+  spec.add_development_dependency "nokogiri", ">= 0"
 
 end

--- a/opensrs.gemspec
+++ b/opensrs.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.version       = OpenSRS::Version::VERSION
   spec.authors       = ["Joshua Delsman"]
   spec.email         = ["voxxit@users.noreply.github.com"]
-  spec.summary       = "Provides support to utilize the OpenSRS API with Ruby/Rails."
+  spec.summary       = "OpenSRS API for Ruby"
   spec.description   = "Provides support to utilize the OpenSRS API with Ruby/Rails."
   spec.homepage      = "https://github.com/voxxit/opensrs"
   spec.license       = "MIT"
@@ -22,12 +22,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "libxml-ruby"
+  spec.add_runtime_dependency "libxml-ruby", "~> 0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "shoulda"
-  spec.add_development_dependency "nokogiri"
+  spec.add_development_dependency "rspec", "~> 2.0"
+  spec.add_development_dependency "shoulda", "~> 0"
+  spec.add_development_dependency "nokogiri", "~> 0"
 
 end

--- a/spec/opensrs/xml_processor/nokogiri_spec.rb
+++ b/spec/opensrs/xml_processor/nokogiri_spec.rb
@@ -1,4 +1,3 @@
-require 'date'
 OpenSRS::Server.xml_processor = :nokogiri
 
 class OrderedHash < Hash


### PR DESCRIPTION
Libxml is a very old gem, with tons of C problems (static stuff that makes GC crazy)
We've been stuck about 3 weeks with tons of segfaults because of it.

Problem with libxml is that, even if you don't use it anywhere, it override the constant XML and will be "in control" of xml parsing everywhere (and destroy your entire runtime).

This patch needs a doc update. 

## How to install

```ruby
gem 'opensrs'
gem 'nokogiri' # if you want to use nokogiri as XML Parser
gem 'libxml-ruby' # if you want to use libxml as XML Parser 
```

In your software initialization:

```ruby
OpenSRS::Server.xml_processor = :nokogiri
```