### PR TITLE
Update libxml.rb

### DIFF
--- a/lib/opensrs/xml_processor/libxml.rb
+++ b/lib/opensrs/xml_processor/libxml.rb
@@ -48,8 +48,11 @@ module OpenSRS
         dt_assoc = {}
 
         element.children.each do |item|
-          next if item.content.strip.empty?
-          dt_assoc[item.attributes["key"]] = decode_data(item)
+          if item.children.empty?
+            dt_assoc[item.attributes["key"]] = ""
+          else
+            dt_assoc[item.attributes["key"]] = decode_data(item)
+          end
         end
 
         return dt_assoc


### PR DESCRIPTION
Previously, xml processor failed on properly parsing xml which includes tags with empty value. 
For example, the following xml
```<OPS_envelope>
<header>
<version>0.9</version>
</header>
<body>
<data_block>
<dt_assoc>
<item key="protocol">XCP</item>
<item key="object">DOMAIN</item>
<item key="response_text">Query Successful</item>
<item key="action">REPLY</item>
<item key="attributes">
<dt_assoc>
<item key="password"/>
</dt_assoc>
</item>
<item key="response_code">200</item>
<item key="is_success">1</item>
</dt_assoc>
</data_block>
</body>
</OPS_envelope>
```

will be missing attributes key when parsed to hash
```
{
"protocol"=>"XCP",
 "object"=>"DOMAIN",
 "response_text"=>"Query Successful",
 "action"=>"REPLY",
 "response_code"=>"200",
 "is_success"=>"1"
}
```
The proper parsing result after change was applied
```
{
"protocol"=>"XCP",
 "object"=>"DOMAIN",
 "response_text"=>"Query Successful",
 "action"=>"REPLY",
 "attributes"=>{"password"=>""},
 "response_code"=>"200",
 "is_success"=>"1"
}
```