### PR TITLE
Adding fix for handling empty keys , such that key will be presented in response

### DIFF
--- a/lib/opensrs/xml_processor.rb
+++ b/lib/opensrs/xml_processor.rb
@@ -3,12 +3,13 @@ module OpenSRS
 
     # Parses the main data block from OpenSRS and discards
     # the rest of the response.
-    def self.parse(response)
+    def self.parse(raw_xml)
+
+      # get rid of all whitespace between xml tags
+      response = raw_xml.gsub(/>\s+</,'><')
       data_block = data_block_element(response)
-
       raise ArgumentError.new("No data found in document") if !data_block
-
-      return decode_data(data_block)
+      decode_data(data_block)
     end
 
     protected

--- a/lib/opensrs/xml_processor/libxml.rb
+++ b/lib/opensrs/xml_processor/libxml.rb
@@ -28,8 +28,8 @@ module OpenSRS
 
       protected
 
-      def self.data_block_element(response)
-        doc = Parser.string(response).parse
+      def self.data_block_element(raw_xml)
+        doc = Parser.string(raw_xml).parse
         return doc.find("//OPS_envelope/body/data_block/*")
       end
 
@@ -48,8 +48,11 @@ module OpenSRS
         dt_assoc = {}
 
         element.children.each do |item|
-          next if item.content.strip.empty?
-          dt_assoc[item.attributes["key"]] = decode_data(item)
+          if item.children.empty?
+            dt_assoc[item.attributes["key"]] = ""
+          else
+            dt_assoc[item.attributes["key"]] = decode_data(item)
+          end
         end
 
         return dt_assoc

--- a/lib/opensrs/xml_processor/nokogiri.rb
+++ b/lib/opensrs/xml_processor/nokogiri.rb
@@ -50,8 +50,11 @@ module OpenSRS
         dt_assoc = {}
 
         element.children.each do |item|
-          next if item.content.strip.empty?
-          dt_assoc[item.attributes["key"].value] = decode_data(item.children)
+          if item.content.strip.empty?
+            dt_assoc[item.attributes["key"].value] = ""
+          else
+            dt_assoc[item.attributes["key"].value] = decode_data(item.children)
+          end
         end
 
         return dt_assoc


### PR DESCRIPTION
I have run in to the problem when I'm expecting key with no value (empty string/ nil is not that important). But instead no key present in response and it's only available in raw_response
