### PR TITLE
Sanitize SW_REGISTER logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ with OpenSRS. The assumption is you are using a Rails-like logger, but as long a
 are fine. You can simply assign the logger or pass it in as an initialization option:
 
     server = OpenSRS::Server.new(
-      server:   "https://rr-n1-tor.opensrs.net:55443/",
-      username: "testing",
-      password: "53cr3t",
-      key:      "c633be3170c7fb3fb29e2f99b84be2410...",
-      logger:   Rails.logger
+      server:        "https://rr-n1-tor.opensrs.net:55443/",
+      username:      "testing",
+      password:      "53cr3t",
+      key:           "c633be3170c7fb3fb29e2f99b84be2410...",
+      logger:        Rails.logger,
+      sanitize_logs: false
     )
 
 or, if you can change it later:

--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -11,20 +11,27 @@ module OpenSRS
   class TimeoutError < ConnectionError; end
 
   class Server
-    attr_accessor :server, :username, :password, :key, :timeout, :open_timeout, :logger, :sanitize_logs
+    attr_accessor :server,
+                  :username,
+                  :password,
+                  :key,
+                  :timeout,
+                  :open_timeout,
+                  :logger,
+                  :sanitize_logs
 
     SANITIZING_METHODS = [
       :sanitize_rw_register
-    ]
+    ].freeze
 
     def initialize(options = {})
-      @server        = URI.parse(options[:server] || "https://rr-n1-tor.opensrs.net:55443/")
-      @username      = options[:username]
-      @password      = options[:password]
-      @key           = options[:key]
-      @timeout       = options[:timeout]
-      @open_timeout  = options[:open_timeout]
-      @logger        = options[:logger]
+      @server   = URI.parse(options[:server] || "https://rr-n1-tor.opensrs.net:55443/")
+      @username = options[:username]
+      @password = options[:password]
+      @key      = options[:key]
+      @timeout  = options[:timeout]
+      @open_timeout = options[:open_timeout]
+      @logger   = options[:logger]
       @sanitize_logs = options[:sanitize_logs]
     end
 
@@ -83,13 +90,17 @@ module OpenSRS
     def sanitize(type, data, options)
       return data unless @sanitize_logs
 
-      SANITIZING_METHODS.reduce(data) { |current_data, method| self.send(method, type, current_data, options) }
+      SANITIZING_METHODS.inject(data) do |current_data, method|
+        send(method, type, current_data, options)
+      end
     end
 
     def sanitize_rw_register(type, data, options)
-      return data unless type == 'Request' && options[:object] == 'DOMAIN' && options[:action] == 'SW_REGISTER'
+      return data unless type == "Request" &&
+                         options[:object] == "DOMAIN" &&
+                         options[:action] == "SW_REGISTER"
 
-      data.gsub(/(<item key="reg_password">).*(<\/item>)/, '\1**sanitized**\2')
+      data.gsub(%r{(<item key="reg_password">).*(</item>)}, '\1**sanitized**\2')
     end
 
     def log(type, data, options = {})

--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -11,16 +11,21 @@ module OpenSRS
   class TimeoutError < ConnectionError; end
 
   class Server
-    attr_accessor :server, :username, :password, :key, :timeout, :open_timeout, :logger
+    attr_accessor :server, :username, :password, :key, :timeout, :open_timeout, :logger, :sanitize_logs
+
+    SANITIZING_METHODS = [
+      :sanitize_rw_register
+    ]
 
     def initialize(options = {})
-      @server   = URI.parse(options[:server] || "https://rr-n1-tor.opensrs.net:55443/")
-      @username = options[:username]
-      @password = options[:password]
-      @key      = options[:key]
-      @timeout  = options[:timeout]
-      @open_timeout = options[:open_timeout]
-      @logger   = options[:logger]
+      @server        = URI.parse(options[:server] || "https://rr-n1-tor.opensrs.net:55443/")
+      @username      = options[:username]
+      @password      = options[:password]
+      @key           = options[:key]
+      @timeout       = options[:timeout]
+      @open_timeout  = options[:open_timeout]
+      @logger        = options[:logger]
+      @sanitize_logs = options[:sanitize_logs]
     end
 
     def call(data = {})
@@ -75,13 +80,25 @@ module OpenSRS
       http
     end
 
+    def sanitize(type, data, options)
+      return data unless @sanitize_logs
+
+      SANITIZING_METHODS.reduce(data) { |current_data, method| self.send(method, type, current_data, options) }
+    end
+
+    def sanitize_rw_register(type, data, options)
+      return data unless type == 'Request' && options[:object] == 'DOMAIN' && options[:action] == 'SW_REGISTER'
+
+      data.gsub(/(<item key="reg_password">).*(<\/item>)/, '\1**sanitized**\2')
+    end
+
     def log(type, data, options = {})
       return unless logger
 
       message = "[OpenSRS] #{type} XML"
       message = "#{message} for #{options[:object]} #{options[:action]}" if options[:object] && options[:action]
 
-      line = [message, data].join("\n")
+      line = [message, sanitize(type, data, options)].join("\n")
       logger.info(line)
     end
 

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -129,7 +129,7 @@ describe OpenSRS::Server do
       end
 
       describe "sanitize_logs" do
-        let(:xml) { '<item key="reg_username">user</item><item key="reg_password">password</item>' }
+        let(:xml) { '<item>foo</item><item key="reg_password">password</item>' }
         before :each do
           xml_processor.stub(:build).and_return xml
           xml_processor.stub(:parse).and_return xml
@@ -138,17 +138,21 @@ describe OpenSRS::Server do
         it "if enabled, sw_register's logs should be sanitized" do
           server.sanitize_logs = true
 
-          server.call(action: 'SW_REGISTER', object: 'DOMAIN')
+          server.call(action: "SW_REGISTER", object: "DOMAIN")
 
-          expect(logger.messages.first).to match(/<item key="reg_password">\*\*sanitized\*\*<\/item>/)
+          expect(logger.messages.first).to match(
+            %r{<item key="reg_password">\*\*sanitized\*\*</item>}
+          )
         end
 
         it "if disabled, sw_register's logs should not be sanitized" do
           server.sanitize_logs = false
 
-          server.call(action: 'SW_REGISTER', object: 'DOMAIN')
+          server.call(action: "SW_REGISTER", object: "DOMAIN")
 
-          expect(logger.messages.first).to match(/<item key="reg_password">password<\/item>/)
+          expect(logger.messages.first).to match(
+            %r{<item key="reg_password">password<\/item>}
+          )
         end
       end
     end

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -128,6 +128,29 @@ describe OpenSRS::Server do
         expect(logger.messages.last).to match(/some response/)
       end
 
+      describe "sanitize_logs" do
+        let(:xml) { '<item key="reg_username">user</item><item key="reg_password">password</item>' }
+        before :each do
+          xml_processor.stub(:build).and_return xml
+          xml_processor.stub(:parse).and_return xml
+        end
+
+        it "if enabled, sw_register's logs should be sanitized" do
+          server.sanitize_logs = true
+
+          server.call(action: 'SW_REGISTER', object: 'DOMAIN')
+
+          expect(logger.messages.first).to match(/<item key="reg_password">\*\*sanitized\*\*<\/item>/)
+        end
+
+        it "if disabled, sw_register's logs should not be sanitized" do
+          server.sanitize_logs = false
+
+          server.call(action: 'SW_REGISTER', object: 'DOMAIN')
+
+          expect(logger.messages.first).to match(/<item key="reg_password">password<\/item>/)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This PR is adding a way to sanitize sensitive logs. I realized that my logs were containing sensitive information (AKA. user passwords from the `RW_REGISTER` call) and that was not acceptable. This is a opt-in setting, so "old" code should be working the same way it was.