### PR TITLE
Sanitize xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Responses from OpenSRS are returned in an OpenSRS::Response object, which gives 
   Method | Description
   ---|---
   `response.response` | This gives you the response in a Hash form, which is highly accessible to most other actions in your application.
-  `response.response` | This gives you the response in a Hash form, which is highly accessible to most other actions in your application.
   `response.errors` | If there are errors which come back from OpenSRS, they are returned here. If not, it returns nil.
   `response.success?` | Returns true if the response was labeled as successful. If not, it returns false.
   `response.request_xml` | Returns raw request XML.

--- a/lib/opensrs.rb
+++ b/lib/opensrs.rb
@@ -1,6 +1,7 @@
 require "opensrs/xml_processor"
 require "opensrs/server"
 require "opensrs/response"
+require "opensrs/sanitizable_string"
 require "opensrs/version"
 
 module OpenSRS

--- a/lib/opensrs/sanitizable_string.rb
+++ b/lib/opensrs/sanitizable_string.rb
@@ -1,0 +1,18 @@
+require 'delegate'
+
+module OpenSRS
+  class SanitizableString < SimpleDelegator
+    def self.enable_sanitization=(enabled)
+      @@enable_sanitization = enabled
+    end
+
+    def initialize(original_string, sanitized_string)
+      super(original_string)
+      @sanitized_string = sanitized_string
+    end
+
+    def sanitized
+      @@enable_sanitization ? @sanitized_string : self
+    end
+  end
+end

--- a/lib/opensrs/sanitizable_string.rb
+++ b/lib/opensrs/sanitizable_string.rb
@@ -1,9 +1,13 @@
+# frozen_string_literal: true
+
 require 'delegate'
 
 module OpenSRS
   class SanitizableString < SimpleDelegator
-    def self.enable_sanitization=(enabled)
-      @@enable_sanitization = enabled
+    @enable_sanitization = false
+
+    class << self
+      attr_accessor :enable_sanitization
     end
 
     def initialize(original_string, sanitized_string)
@@ -12,7 +16,7 @@ module OpenSRS
     end
 
     def sanitized
-      @@enable_sanitization ? @sanitized_string : self
+      self.class.enable_sanitization ? @sanitized_string : self
     end
   end
 end

--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -21,11 +21,12 @@ module OpenSRS
       @timeout  = options[:timeout]
       @open_timeout = options[:open_timeout]
       @logger   = options[:logger]
+      OpenSRS::SanitizableString.enable_sanitization = options[:sanitize_request]
     end
 
     def call(data = {})
       xml = xml_processor.build({ :protocol => "XCP" }.merge!(data))
-      log('Request', xml, data)
+      log('Request', xml.sanitized, data)
 
       begin
         response = http.post(server_path, xml, headers(xml))
@@ -35,7 +36,7 @@ module OpenSRS
       end
 
       parsed_response = xml_processor.parse(response.body)
-      return OpenSRS::Response.new(parsed_response, xml, response.body)
+      return OpenSRS::Response.new(parsed_response, xml.sanitized, response.body)
     rescue Timeout::Error => err
       raise OpenSRS::TimeoutError, err
     rescue Errno::ECONNRESET, Errno::ECONNREFUSED => err

--- a/lib/opensrs/xml_processor/libxml.rb
+++ b/lib/opensrs/xml_processor/libxml.rb
@@ -23,8 +23,22 @@ module OpenSRS
 
         data_block << encode_data(data, data_block)
 
-        return OpenSRS::SanitizableString.new(xml.to_s, sanitize(xml).to_s)
+        OpenSRS::SanitizableString.new(xml.to_s, sanitize(xml).to_s)
       end
+
+      def self.sanitize(doc)
+        # Before changing the iteration through the nodes, read:
+        # https://www.rubydoc.info/gems/libxml-ruby/LibXML/XML/Document#find-instance_method
+
+        username_nodes = doc.find("//item[@key='reg_username']")
+        username_nodes.each { |node| node.content = "FILTERED" }
+
+        password_nodes = doc.find("//item[@key='reg_password']")
+        password_nodes.each { |node| node.content = "FILTERED" }
+
+        doc
+      end
+      private_class_method :sanitize
 
       protected
 
@@ -60,19 +74,6 @@ module OpenSRS
       #
       def self.new_element(element_name, container)
         return Node.new(element_name.to_s)
-      end
-
-      def self.sanitize(doc)
-        # Before changing the iteration through the nodes, read:
-        # https://www.rubydoc.info/gems/libxml-ruby/LibXML/XML/Document#find-instance_method
-
-        username_nodes = doc.find("//item[@key='reg_username']")
-        username_nodes.each { |node| node.content = 'FILTERED' }
-
-        password_nodes = doc.find("//item[@key='reg_password']")
-        password_nodes.each { |node| node.content = 'FILTERED' }
-
-        doc
       end
     end
   end

--- a/lib/opensrs/xml_processor/libxml.rb
+++ b/lib/opensrs/xml_processor/libxml.rb
@@ -23,7 +23,7 @@ module OpenSRS
 
         data_block << encode_data(data, data_block)
 
-        return xml.to_s
+        return OpenSRS::SanitizableString.new(xml.to_s, sanitize(xml).to_s)
       end
 
       protected
@@ -62,6 +62,18 @@ module OpenSRS
         return Node.new(element_name.to_s)
       end
 
+      def self.sanitize(doc)
+        # Before changing the iteration through the nodes, read:
+        # https://www.rubydoc.info/gems/libxml-ruby/LibXML/XML/Document#find-instance_method
+
+        username_nodes = doc.find("//item[@key='reg_username']")
+        username_nodes.each { |node| node.content = 'FILTERED' }
+
+        password_nodes = doc.find("//item[@key='reg_password']")
+        password_nodes.each { |node| node.content = 'FILTERED' }
+
+        doc
+      end
     end
   end
 end

--- a/lib/opensrs/xml_processor/nokogiri.rb
+++ b/lib/opensrs/xml_processor/nokogiri.rb
@@ -25,7 +25,7 @@ module OpenSRS
         data_block << other_data
         body << data_block
         envelope << body
-        return builder.to_xml
+        return OpenSRS::SanitizableString.new(builder.to_xml, sanitize(builder.to_xml))
       end
 
       protected
@@ -61,6 +61,12 @@ module OpenSRS
         return ::Nokogiri::XML::Node.new(element_name.to_s, container)
       end
 
+      def self.sanitize(xml_string)
+        doc = ::Nokogiri::XML(xml_string)
+        doc.xpath("//item[@key='reg_username']").each { |node| node.content = 'FILTERED' }
+        doc.xpath("//item[@key='reg_password']").each { |node| node.content = 'FILTERED' }
+        doc.to_xml
+      end
     end
   end
 end

--- a/lib/opensrs/xml_processor/nokogiri.rb
+++ b/lib/opensrs/xml_processor/nokogiri.rb
@@ -25,8 +25,21 @@ module OpenSRS
         data_block << other_data
         body << data_block
         envelope << body
-        return OpenSRS::SanitizableString.new(builder.to_xml, sanitize(builder.to_xml))
+
+        OpenSRS::SanitizableString.new(builder.to_xml, sanitize(builder.to_xml))
       end
+
+      def self.sanitize(xml_string)
+        doc = ::Nokogiri::XML(xml_string)
+        doc.xpath("//item[@key='reg_username']").each do |node|
+          node.content = "FILTERED"
+        end
+        doc.xpath("//item[@key='reg_password']").each do |node|
+          node.content = "FILTERED"
+        end
+        doc.to_xml
+      end
+      private_class_method :sanitize
 
       protected
 
@@ -59,13 +72,6 @@ module OpenSRS
 
       def self.new_element(element_name, container)
         return ::Nokogiri::XML::Node.new(element_name.to_s, container)
-      end
-
-      def self.sanitize(xml_string)
-        doc = ::Nokogiri::XML(xml_string)
-        doc.xpath("//item[@key='reg_username']").each { |node| node.content = 'FILTERED' }
-        doc.xpath("//item[@key='reg_password']").each { |node| node.content = 'FILTERED' }
-        doc.to_xml
       end
     end
   end

--- a/spec/opensrs/sanitizable_string_spec.rb
+++ b/spec/opensrs/sanitizable_string_spec.rb
@@ -1,0 +1,30 @@
+describe OpenSRS::SanitizableString do
+  subject { described_class.new('string', 'sanitized string') }
+  describe 'sanitizing enabled' do
+    before(:each) do
+      described_class.enable_sanitization = true
+    end
+    it 'returns the sanitized string when asked' do
+      expect(subject.sanitized).to eql 'sanitized string'
+    end
+
+    it 'delegates all string functionality to the original string' do
+      expect(subject.upcase).to eql 'string'.upcase
+      expect(subject.length).to eql 'string'.length
+    end
+  end
+
+  describe 'sanitizing disabled' do
+    before(:each) do
+      described_class.enable_sanitization = false
+    end
+    it 'returns the original string when asked for a sanitized string' do
+      expect(subject.sanitized).to eql 'string'
+    end
+
+    it 'delegates all string functionality to the original string' do
+      expect(subject.upcase).to eql 'string'.upcase
+      expect(subject.length).to eql 'string'.length
+    end
+  end
+end

--- a/spec/opensrs/sanitizable_string_spec.rb
+++ b/spec/opensrs/sanitizable_string_spec.rb
@@ -1,30 +1,32 @@
+# frozen_string_literal: true
+
 describe OpenSRS::SanitizableString do
-  subject { described_class.new('string', 'sanitized string') }
-  describe 'sanitizing enabled' do
+  subject { described_class.new("string", "sanitized string") }
+  describe "sanitizing enabled" do
     before(:each) do
       described_class.enable_sanitization = true
     end
-    it 'returns the sanitized string when asked' do
-      expect(subject.sanitized).to eql 'sanitized string'
+    it "returns the sanitized string when asked" do
+      expect(subject.sanitized).to eql "sanitized string"
     end
 
-    it 'delegates all string functionality to the original string' do
-      expect(subject.upcase).to eql 'string'.upcase
-      expect(subject.length).to eql 'string'.length
+    it "delegates all string functionality to the original string" do
+      expect(subject.upcase).to eql "string".upcase
+      expect(subject.length).to eql 6
     end
   end
 
-  describe 'sanitizing disabled' do
+  describe "sanitizing disabled" do
     before(:each) do
       described_class.enable_sanitization = false
     end
-    it 'returns the original string when asked for a sanitized string' do
-      expect(subject.sanitized).to eql 'string'
+    it "returns the original string when asked for a sanitized string" do
+      expect(subject.sanitized).to eql "string"
     end
 
-    it 'delegates all string functionality to the original string' do
-      expect(subject.upcase).to eql 'string'.upcase
-      expect(subject.length).to eql 'string'.length
+    it "delegates all string functionality to the original string" do
+      expect(subject.upcase).to eql "string".upcase
+      expect(subject.length).to eql 6
     end
   end
 end

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -42,47 +42,47 @@ describe OpenSRS::Server do
     let(:http) { double(Net::HTTP, :use_ssl= => true, :verify_mode= => true)  }
 
     before :each do
-      server.stub(:headers).and_return header
-      xml_processor.stub(:build).and_return xml
-      xml_processor.stub(:parse).and_return response_xml
-      server.stub(:xml_processor).and_return xml_processor
-      http.stub(:post).and_return response
-      Net::HTTP.stub(:new).and_return http
+      allow(server).to receive(:headers).and_return header
+      allow(xml_processor).to receive(:build).and_return xml
+      allow(xml_processor).to receive(:parse).and_return response_xml
+      allow(server).to receive(:xml_processor).and_return xml_processor
+      allow(http).to receive(:post).and_return response
+      allow(Net::HTTP).to receive(:new).and_return http
     end
 
     it "builds XML request" do
-      xml_processor.should_receive(:build).with(:protocol => "XCP", :some => 'option')
+      expect(xml_processor).to receive(:build).with(:protocol => "XCP", :some => 'option')
       server.call(:some => 'option')
     end
 
     it "posts to given path" do
       server.server = URI.parse 'http://with-path.com/endpoint'
-      http.should_receive(:post).with('/endpoint', xml, header).and_return double.as_null_object
+      expect(http).to receive(:post).with('/endpoint', xml, header).and_return double.as_null_object
       server.call
     end
 
     it "parses the response" do
-      xml_processor.should_receive(:parse).with(response.body)
+      expect(xml_processor).to receive(:parse).with(response.body)
       server.call(:some => 'option')
     end
 
     it "posts to root path" do
       server.server = URI.parse 'http://root-path.com/'
-      http.should_receive(:post).with('/', xml, header).and_return double.as_null_object
+      expect(http).to receive(:post).with('/', xml, header).and_return double.as_null_object
       server.call
     end
 
     it "defaults path to '/'" do
       server.server = URI.parse 'http://no-path.com'
-      http.should_receive(:post).with('/', xml, header).and_return double.as_null_object
+      expect(http).to receive(:post).with('/', xml, header).and_return double.as_null_object
       server.call
     end
 
     it 'allows overriding of default (Net:HTTP) timeouts' do
       server.timeout = 90
 
-      http.should_receive(:open_timeout=).with(90)
-      http.should_receive(:read_timeout=).with(90)
+      expect(http).to receive(:open_timeout=).with(90)
+      expect(http).to receive(:read_timeout=).with(90)
 
       server.call( { :some => 'data' } )
     end
@@ -91,23 +91,23 @@ describe OpenSRS::Server do
       server.timeout = 180
       server.open_timeout = 30
 
-      http.should_receive(:read_timeout=).with(180)
-      http.should_receive(:open_timeout=).with(180)
-      http.should_receive(:open_timeout=).with(30)
+      expect(http).to receive(:read_timeout=).with(180)
+      expect(http).to receive(:open_timeout=).with(180)
+      expect(http).to receive(:open_timeout=).with(30)
 
       server.call( { :some => 'data' } )
     end
 
     it 're-raises Net:HTTP timeouts' do
-      http.should_receive(:post).and_raise err = Timeout::Error.new('test')
+      expect(http).to receive(:post).and_raise err = Timeout::Error.new('test')
       expect { server.call }.to raise_exception OpenSRS::TimeoutError
     end
 
     it 'wraps connection errors' do
-      http.should_receive(:post).and_raise err = Errno::ECONNREFUSED
+      expect(http).to receive(:post).and_raise err = Errno::ECONNREFUSED
       expect { server.call }.to raise_exception OpenSRS::ConnectionError
 
-      http.should_receive(:post).and_raise err = Errno::ECONNRESET
+      expect(http).to receive(:post).and_raise err = Errno::ECONNRESET
       expect { server.call }.to raise_exception OpenSRS::ConnectionError
     end
 
@@ -118,7 +118,7 @@ describe OpenSRS::Server do
       end
 
       it "should log the request and the response" do
-        xml_processor.should_receive(:build).with(:protocol => "XCP", :some => 'option')
+        expect(xml_processor). to receive(:build).with(:protocol => "XCP", :some => 'option')
         server.call(:some => 'option')
 
         expect(logger.messages.length).to be(2)

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -37,10 +37,12 @@ describe OpenSRS::Server do
     let(:response) { double(:body => 'some response') }
     let(:header) { {"some" => "header" } }
     let(:wrapped_xml) do
-      OpenSRS::SanitizableString.new(request_xml, '<sanitized xml></sanitized xml>')
+      OpenSRS::SanitizableString.new(
+        request_xml, "<sanitized xml></sanitized xml>"
+      )
     end
-    let(:xml) { '<some xml></some xml>' }
-    let(:request_xml) { '<some request xml></some request xml>' }
+    let(:xml) { "<some xml></some xml>" }
+    let(:request_xml) { "<some request xml></some request xml>" }
     let(:response_xml) { xml }
     let(:xml_processor) { double OpenSRS::XmlProcessor }
     let(:http) { double(Net::HTTP, :use_ssl= => true, :verify_mode= => true)  }
@@ -55,13 +57,15 @@ describe OpenSRS::Server do
     end
 
     it "builds XML request" do
-      expect(xml_processor).to receive(:build).with(:protocol => "XCP", :some => 'option')
-      server.call(:some => 'option')
+      expect(xml_processor).to receive(:build).
+        with(protocol: "XCP", some: "option")
+      server.call(some: "option")
     end
 
     it "posts to given path" do
-      server.server = URI.parse 'http://with-path.com/endpoint'
-      expect(http).to receive(:post).with('/endpoint', request_xml, header).and_return double.as_null_object
+      server.server = URI.parse "http://with-path.com/endpoint"
+      expect(http).to receive(:post).with("/endpoint", request_xml, header).
+        and_return double.as_null_object
       server.call
     end
 
@@ -71,14 +75,16 @@ describe OpenSRS::Server do
     end
 
     it "posts to root path" do
-      server.server = URI.parse 'http://root-path.com/'
-      expect(http).to receive(:post).with('/', request_xml, header).and_return double.as_null_object
+      server.server = URI.parse "http://root-path.com/"
+      expect(http).to receive(:post).with("/", request_xml, header).
+        and_return double.as_null_object
       server.call
     end
 
     it "defaults path to '/'" do
-      server.server = URI.parse 'http://no-path.com'
-      expect(http).to receive(:post).with('/', request_xml, header).and_return double.as_null_object
+      server.server = URI.parse "http://no-path.com"
+      expect(http).to receive(:post).with("/", request_xml, header).
+        and_return double.as_null_object
       server.call
     end
 
@@ -103,20 +109,20 @@ describe OpenSRS::Server do
     end
 
     it 're-raises Net:HTTP timeouts' do
-      expect(http).to receive(:post).and_raise err = Timeout::Error.new('test')
+      expect(http).to receive(:post).and_raise Timeout::Error.new("test")
       expect { server.call }.to raise_exception OpenSRS::TimeoutError
     end
 
     it 'wraps connection errors' do
-      expect(http).to receive(:post).and_raise err = Errno::ECONNREFUSED
+      expect(http).to receive(:post).and_raise Errno::ECONNREFUSED
       expect { server.call }.to raise_exception OpenSRS::ConnectionError
 
-      expect(http).to receive(:post).and_raise err = Errno::ECONNRESET
+      expect(http).to receive(:post).and_raise Errno::ECONNRESET
       expect { server.call }.to raise_exception OpenSRS::ConnectionError
     end
 
-    it 'returns a response object' do
-      result = server.call(:some => 'option')
+    it "returns a response object" do
+      result = server.call(some: "option")
 
       expect(result).to be_a OpenSRS::Response
       expect(result.request_xml).to eql request_xml
@@ -131,8 +137,9 @@ describe OpenSRS::Server do
       end
 
       it "should log the request and the response" do
-        expect(xml_processor). to receive(:build).with(:protocol => "XCP", :some => 'option')
-        server.call(:some => 'option')
+        expect(xml_processor). to receive(:build).
+          with(protocol: "XCP", some: "option")
+        server.call(some: "option")
 
         expect(logger.messages.length).to be(2)
         expect(logger.messages.first).to match(/\[OpenSRS\] Request XML/)
@@ -145,8 +152,8 @@ describe OpenSRS::Server do
     describe "xml sanitization has been enabled" do
       let(:server) { OpenSRS::Server.new(sanitize_request: true) }
 
-      it 'populates the returned request instance with sanitized xml' do
-        result = server.call(:some => 'option')
+      it "populates the returned request instance with sanitized xml" do
+        result = server.call(some: "option")
 
         expect(result).to be_a OpenSRS::Response
         expect(result.request_xml).to eql wrapped_xml.sanitized
@@ -161,8 +168,9 @@ describe OpenSRS::Server do
         end
 
         it "should log the request and the sanitized response" do
-          expect(xml_processor). to receive(:build).with(:protocol => "XCP", :some => 'option')
-          server.call(:some => 'option')
+          expect(xml_processor). to receive(:build).
+            with(protocol: "XCP", some: "option")
+          server.call(some: "option")
 
           expect(logger.messages.length).to be(2)
           expect(logger.messages.first).to match(/\[OpenSRS\] Request XML/)

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -36,14 +36,18 @@ describe OpenSRS::Server do
   describe ".call" do
     let(:response) { double(:body => 'some response') }
     let(:header) { {"some" => "header" } }
+    let(:wrapped_xml) do
+      OpenSRS::SanitizableString.new(request_xml, '<sanitized xml></sanitized xml>')
+    end
     let(:xml) { '<some xml></some xml>' }
+    let(:request_xml) { '<some request xml></some request xml>' }
     let(:response_xml) { xml }
     let(:xml_processor) { double OpenSRS::XmlProcessor }
     let(:http) { double(Net::HTTP, :use_ssl= => true, :verify_mode= => true)  }
 
     before :each do
       allow(server).to receive(:headers).and_return header
-      allow(xml_processor).to receive(:build).and_return xml
+      allow(xml_processor).to receive(:build).and_return wrapped_xml
       allow(xml_processor).to receive(:parse).and_return response_xml
       allow(server).to receive(:xml_processor).and_return xml_processor
       allow(http).to receive(:post).and_return response
@@ -57,7 +61,7 @@ describe OpenSRS::Server do
 
     it "posts to given path" do
       server.server = URI.parse 'http://with-path.com/endpoint'
-      expect(http).to receive(:post).with('/endpoint', xml, header).and_return double.as_null_object
+      expect(http).to receive(:post).with('/endpoint', request_xml, header).and_return double.as_null_object
       server.call
     end
 
@@ -68,13 +72,13 @@ describe OpenSRS::Server do
 
     it "posts to root path" do
       server.server = URI.parse 'http://root-path.com/'
-      expect(http).to receive(:post).with('/', xml, header).and_return double.as_null_object
+      expect(http).to receive(:post).with('/', request_xml, header).and_return double.as_null_object
       server.call
     end
 
     it "defaults path to '/'" do
       server.server = URI.parse 'http://no-path.com'
-      expect(http).to receive(:post).with('/', xml, header).and_return double.as_null_object
+      expect(http).to receive(:post).with('/', request_xml, header).and_return double.as_null_object
       server.call
     end
 
@@ -111,6 +115,15 @@ describe OpenSRS::Server do
       expect { server.call }.to raise_exception OpenSRS::ConnectionError
     end
 
+    it 'returns a response object' do
+      result = server.call(:some => 'option')
+
+      expect(result).to be_a OpenSRS::Response
+      expect(result.request_xml).to eql request_xml
+      expect(result.response_xml).to eql response.body
+      expect(result.response).to eql response_xml
+    end
+
     describe "logger is present" do
       let(:logger) { OpenSRS::TestLogger.new }
       before :each do
@@ -123,11 +136,41 @@ describe OpenSRS::Server do
 
         expect(logger.messages.length).to be(2)
         expect(logger.messages.first).to match(/\[OpenSRS\] Request XML/)
-        expect(logger.messages.first).to match(/<some xml>/)
+        expect(logger.messages.first).to match(/<some request xml>/)
         expect(logger.messages.last).to match(/\[OpenSRS\] Response XML/)
         expect(logger.messages.last).to match(/some response/)
       end
+    end
 
+    describe "xml sanitization has been enabled" do
+      let(:server) { OpenSRS::Server.new(sanitize_request: true) }
+
+      it 'populates the returned request instance with sanitized xml' do
+        result = server.call(:some => 'option')
+
+        expect(result).to be_a OpenSRS::Response
+        expect(result.request_xml).to eql wrapped_xml.sanitized
+        expect(result.response_xml).to eql response.body
+        expect(result.response).to eql response_xml
+      end
+
+      describe "logger is present" do
+        let(:logger) { OpenSRS::TestLogger.new }
+        before :each do
+          server.logger = logger
+        end
+
+        it "should log the request and the sanitized response" do
+          expect(xml_processor). to receive(:build).with(:protocol => "XCP", :some => 'option')
+          server.call(:some => 'option')
+
+          expect(logger.messages.length).to be(2)
+          expect(logger.messages.first).to match(/\[OpenSRS\] Request XML/)
+          expect(logger.messages.first).to match(/<sanitized xml>/)
+          expect(logger.messages.last).to match(/\[OpenSRS\] Response XML/)
+          expect(logger.messages.last).to match(/some response/)
+        end
+      end
     end
   end
 

--- a/spec/opensrs/xml_processor/libxml_spec.rb
+++ b/spec/opensrs/xml_processor/libxml_spec.rb
@@ -2,23 +2,39 @@ OpenSRS::Server.xml_processor = :libxml
 
 describe OpenSRS::XmlProcessor::Libxml do
   describe ".build" do
+    let(:support_dir) do
+      File.join(File.dirname(__FILE__), '..', '..', 'support', 'libxml')
+    end
+    let(:xml) do
+      IO.read(File.join(support_dir, 'xml.xml'))
+    end
+    let(:xml_with_credentials) do
+      IO.read(File.join(support_dir, 'xml_with_credentials.xml'))
+    end
+    let(:xml_with_sanitized_credentials) do
+      IO.read(File.join(support_dir, 'xml_with_sanitized_credentials.xml'))
+    end
     it "should create XML for a nested hash" do
-      attributes = {:foo => {:bar => 'baz'}}
+      attributes = { foo: { bar: "baz" } }
       xml = OpenSRS::XmlProcessor::Libxml.build(attributes)
 
-      expect(xml).to eq %{<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+      expect(xml).to eq xml
     end
 
     it "includes a sanitized version in the response" do
       OpenSRS::SanitizableString.enable_sanitization = true
       attributes = {
-        :foo => {:bar => 'baz', reg_username: 'donaldduck', reg_password: 'secret123'},
-        :monkeys => {:bar => 'foo', reg_username: 'mickeymouse', reg_password: 'secret456'},
+        foo: {
+          bar: "baz", reg_username: "donaldduck", reg_password: "secret123"
+        },
+        monkeys: {
+          bar: "foo", reg_username: "mickeymouse", reg_password: "secret456"
+        }
       }
       xml = OpenSRS::XmlProcessor::Libxml.build(attributes)
 
-      expect(xml).to eq %{<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n            <item key=\"reg_username\">donaldduck</item>\n            <item key=\"reg_password\">secret123</item>\n          </dt_assoc>\n        </item>\n        <item key=\"monkeys\">\n          <dt_assoc>\n            <item key=\"bar\">foo</item>\n            <item key=\"reg_username\">mickeymouse</item>\n            <item key=\"reg_password\">secret456</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
-      expect(xml.sanitized).to eq %{<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n            <item key=\"reg_username\">FILTERED</item>\n            <item key=\"reg_password\">FILTERED</item>\n          </dt_assoc>\n        </item>\n        <item key=\"monkeys\">\n          <dt_assoc>\n            <item key=\"bar\">foo</item>\n            <item key=\"reg_username\">FILTERED</item>\n            <item key=\"reg_password\">FILTERED</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+      expect(xml).to eql xml_with_credentials
+      expect(xml.sanitized).to eql xml_with_sanitized_credentials
     end
   end
 

--- a/spec/opensrs/xml_processor/libxml_spec.rb
+++ b/spec/opensrs/xml_processor/libxml_spec.rb
@@ -8,6 +8,18 @@ describe OpenSRS::XmlProcessor::Libxml do
 
       expect(xml).to eq %{<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
     end
+
+    it "includes a sanitized version in the response" do
+      OpenSRS::SanitizableString.enable_sanitization = true
+      attributes = {
+        :foo => {:bar => 'baz', reg_username: 'donaldduck', reg_password: 'secret123'},
+        :monkeys => {:bar => 'foo', reg_username: 'mickeymouse', reg_password: 'secret456'},
+      }
+      xml = OpenSRS::XmlProcessor::Libxml.build(attributes)
+
+      expect(xml).to eq %{<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n            <item key=\"reg_username\">donaldduck</item>\n            <item key=\"reg_password\">secret123</item>\n          </dt_assoc>\n        </item>\n        <item key=\"monkeys\">\n          <dt_assoc>\n            <item key=\"bar\">foo</item>\n            <item key=\"reg_username\">mickeymouse</item>\n            <item key=\"reg_password\">secret456</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+      expect(xml.sanitized).to eq %{<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n            <item key=\"reg_username\">FILTERED</item>\n            <item key=\"reg_password\">FILTERED</item>\n          </dt_assoc>\n        </item>\n        <item key=\"monkeys\">\n          <dt_assoc>\n            <item key=\"bar\">foo</item>\n            <item key=\"reg_username\">FILTERED</item>\n            <item key=\"reg_password\">FILTERED</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+    end
   end
 
   describe '.encode_data' do

--- a/spec/opensrs/xml_processor/nokogiri_spec.rb
+++ b/spec/opensrs/xml_processor/nokogiri_spec.rb
@@ -5,22 +5,39 @@ end
 
 describe OpenSRS::XmlProcessor::Nokogiri do
   describe ".build" do
+    let(:support_dir) do
+      File.join(File.dirname(__FILE__), "..", "..", "support", "nokogiri")
+    end
+    let(:xml) do
+      IO.read(File.join(support_dir, "xml.xml"))
+    end
+    let(:xml_with_credentials) do
+      IO.read(File.join(support_dir, "xml_with_credentials.xml"))
+    end
+    let(:xml_with_sanitized_credentials) do
+      IO.read(File.join(support_dir, "xml_with_sanitized_credentials.xml"))
+    end
+
     it "should create XML for a nested hash" do
-      attributes = {:foo => {:bar => 'baz'}}
+      attributes = { foo: { bar: "baz" } }
       xml = OpenSRS::XmlProcessor::Nokogiri.build(attributes)
 
-      expect(xml).to eq %{<?xml version=\"1.0\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+      expect(xml).to eq xml
     end
     it "includes a sanitized version in the response" do
       OpenSRS::SanitizableString.enable_sanitization = true
       attributes = {
-        :foo => {:bar => 'baz', reg_username: 'donaldduck', reg_password: 'secret123'},
-        :monkeys => {:bar => 'foo', reg_username: 'mickeymouse', reg_password: 'secret456'},
+        foo: {
+          bar: "baz", reg_username: "donaldduck", reg_password: "secret123"
+        },
+        monkeys: {
+          bar: "foo", reg_username: "mickeymouse", reg_password: "secret456"
+        }
       }
       xml = OpenSRS::XmlProcessor::Nokogiri.build(attributes)
 
-      expect(xml).to eq %{<?xml version=\"1.0\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n            <item key=\"reg_username\">donaldduck</item>\n            <item key=\"reg_password\">secret123</item>\n          </dt_assoc>\n        </item>\n        <item key=\"monkeys\">\n          <dt_assoc>\n            <item key=\"bar\">foo</item>\n            <item key=\"reg_username\">mickeymouse</item>\n            <item key=\"reg_password\">secret456</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
-      expect(xml.sanitized).to eq %{<?xml version=\"1.0\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n            <item key=\"reg_username\">FILTERED</item>\n            <item key=\"reg_password\">FILTERED</item>\n          </dt_assoc>\n        </item>\n        <item key=\"monkeys\">\n          <dt_assoc>\n            <item key=\"bar\">foo</item>\n            <item key=\"reg_username\">FILTERED</item>\n            <item key=\"reg_password\">FILTERED</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+      expect(xml).to eql xml_with_credentials
+      expect(xml.sanitized).to eql xml_with_sanitized_credentials
     end
   end
 

--- a/spec/opensrs/xml_processor/nokogiri_spec.rb
+++ b/spec/opensrs/xml_processor/nokogiri_spec.rb
@@ -11,6 +11,17 @@ describe OpenSRS::XmlProcessor::Nokogiri do
 
       expect(xml).to eq %{<?xml version=\"1.0\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
     end
+    it "includes a sanitized version in the response" do
+      OpenSRS::SanitizableString.enable_sanitization = true
+      attributes = {
+        :foo => {:bar => 'baz', reg_username: 'donaldduck', reg_password: 'secret123'},
+        :monkeys => {:bar => 'foo', reg_username: 'mickeymouse', reg_password: 'secret456'},
+      }
+      xml = OpenSRS::XmlProcessor::Nokogiri.build(attributes)
+
+      expect(xml).to eq %{<?xml version=\"1.0\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n            <item key=\"reg_username\">donaldduck</item>\n            <item key=\"reg_password\">secret123</item>\n          </dt_assoc>\n        </item>\n        <item key=\"monkeys\">\n          <dt_assoc>\n            <item key=\"bar\">foo</item>\n            <item key=\"reg_username\">mickeymouse</item>\n            <item key=\"reg_password\">secret456</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+      expect(xml.sanitized).to eq %{<?xml version=\"1.0\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n            <item key=\"reg_username\">FILTERED</item>\n            <item key=\"reg_password\">FILTERED</item>\n          </dt_assoc>\n        </item>\n        <item key=\"monkeys\">\n          <dt_assoc>\n            <item key=\"bar\">foo</item>\n            <item key=\"reg_username\">FILTERED</item>\n            <item key=\"reg_password\">FILTERED</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+    end
   end
 
   describe '.encode_data' do

--- a/spec/support/libxml/xml.xml
+++ b/spec/support/libxml/xml.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OPS_envelope>
+  <header>
+    <version>0.9</version>
+  </header>
+  <body>
+    <data_block>
+      <dt_assoc>
+        <item key="foo">
+          <dt_assoc>
+            <item key="bar">baz</item>
+          </dt_assoc>
+        </item>
+      </dt_assoc>
+    </data_block>
+  </body>
+</OPS_envelope>

--- a/spec/support/libxml/xml_with_credentials.xml
+++ b/spec/support/libxml/xml_with_credentials.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OPS_envelope>
+  <header>
+    <version>0.9</version>
+  </header>
+  <body>
+    <data_block>
+      <dt_assoc>
+        <item key="foo">
+          <dt_assoc>
+            <item key="bar">baz</item>
+            <item key="reg_username">donaldduck</item>
+            <item key="reg_password">secret123</item>
+          </dt_assoc>
+        </item>
+        <item key="monkeys">
+          <dt_assoc>
+            <item key="bar">foo</item>
+            <item key="reg_username">mickeymouse</item>
+            <item key="reg_password">secret456</item>
+          </dt_assoc>
+        </item>
+      </dt_assoc>
+    </data_block>
+  </body>
+</OPS_envelope>

--- a/spec/support/libxml/xml_with_sanitized_credentials.xml
+++ b/spec/support/libxml/xml_with_sanitized_credentials.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OPS_envelope>
+  <header>
+    <version>0.9</version>
+  </header>
+  <body>
+    <data_block>
+      <dt_assoc>
+        <item key="foo">
+          <dt_assoc>
+            <item key="bar">baz</item>
+            <item key="reg_username">FILTERED</item>
+            <item key="reg_password">FILTERED</item>
+          </dt_assoc>
+        </item>
+        <item key="monkeys">
+          <dt_assoc>
+            <item key="bar">foo</item>
+            <item key="reg_username">FILTERED</item>
+            <item key="reg_password">FILTERED</item>
+          </dt_assoc>
+        </item>
+      </dt_assoc>
+    </data_block>
+  </body>
+</OPS_envelope>

--- a/spec/support/nokogiri/xml.xml
+++ b/spec/support/nokogiri/xml.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<OPS_envelope>
+  <header>
+    <version>0.9</version>
+  </header>
+  <body>
+    <data_block>
+      <dt_assoc>
+        <item key="foo">
+          <dt_assoc>
+            <item key="bar">baz</item>
+          </dt_assoc>
+        </item>
+      </dt_assoc>
+    </data_block>
+  </body>
+</OPS_envelope>

--- a/spec/support/nokogiri/xml_with_credentials.xml
+++ b/spec/support/nokogiri/xml_with_credentials.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<OPS_envelope>
+  <header>
+    <version>0.9</version>
+  </header>
+  <body>
+    <data_block>
+      <dt_assoc>
+        <item key="foo">
+          <dt_assoc>
+            <item key="bar">baz</item>
+            <item key="reg_username">donaldduck</item>
+            <item key="reg_password">secret123</item>
+          </dt_assoc>
+        </item>
+        <item key="monkeys">
+          <dt_assoc>
+            <item key="bar">foo</item>
+            <item key="reg_username">mickeymouse</item>
+            <item key="reg_password">secret456</item>
+          </dt_assoc>
+        </item>
+      </dt_assoc>
+    </data_block>
+  </body>
+</OPS_envelope>

--- a/spec/support/nokogiri/xml_with_sanitized_credentials.xml
+++ b/spec/support/nokogiri/xml_with_sanitized_credentials.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<OPS_envelope>
+  <header>
+    <version>0.9</version>
+  </header>
+  <body>
+    <data_block>
+      <dt_assoc>
+        <item key="foo">
+          <dt_assoc>
+            <item key="bar">baz</item>
+            <item key="reg_username">FILTERED</item>
+            <item key="reg_password">FILTERED</item>
+          </dt_assoc>
+        </item>
+        <item key="monkeys">
+          <dt_assoc>
+            <item key="bar">foo</item>
+            <item key="reg_username">FILTERED</item>
+            <item key="reg_password">FILTERED</item>
+          </dt_assoc>
+        </item>
+      </dt_assoc>
+    </data_block>
+  </body>
+</OPS_envelope>


### PR DESCRIPTION
This is a more generalised version of https://github.com/voxxit/opensrs/pull/35 as I needed the sanitization to not only apply to the logging but to the response instance returned as well. I have set it up so that sanitization is opt-in, so as to protect existing behaviour. 

If you do accept the PR, could you please give a tip of the hat to https://hetzner.co.za/ as they paid for the work.

Also, nice neat codebase - enjoyed making these changes. I also did a little bit of housekeeping (can't help myself, sorry) - but those are in separate commits.

