### PR TITLE
Prevents bad string encoding

### DIFF
--- a/lib/opensrs/xml_processor.rb
+++ b/lib/opensrs/xml_processor.rb
@@ -46,7 +46,12 @@ module OpenSRS
 
         value = item.is_a?(Array) ? item[1] : item
 
-        item_node << encode_data(value, item_node)
+        encoded_data = encode_data(value, item_node)
+        if encoded_data.is_a?(String)
+          item_node.content = encoded_data
+        else
+          item_node << encoded_data
+        end
         element << item_node
       end
 

--- a/spec/opensrs/xml_processor/libxml_spec.rb
+++ b/spec/opensrs/xml_processor/libxml_spec.rb
@@ -8,6 +8,13 @@ describe OpenSRS::XmlProcessor::Libxml do
 
       expect(xml).to eq %{<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
     end
+
+    it "should encode trailing '<'" do
+      attributes = { foo: { bar: "baz&<" } }
+      xml = OpenSRS::XmlProcessor::Libxml.build(attributes)
+
+      expect(xml).to eq %{<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz&amp;&lt;</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+    end
   end
 
   describe '.encode_data' do

--- a/spec/opensrs/xml_processor/nokogiri_spec.rb
+++ b/spec/opensrs/xml_processor/nokogiri_spec.rb
@@ -11,6 +11,13 @@ describe OpenSRS::XmlProcessor::Nokogiri do
 
       expect(xml).to eq %{<?xml version=\"1.0\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
     end
+
+    it "should encode trailing '<'" do
+      attributes = { foo: { bar: "baz&<" } }
+      xml = OpenSRS::XmlProcessor::Nokogiri.build(attributes)
+
+      expect(xml).to eq %{<?xml version=\"1.0\"?>\n<OPS_envelope>\n  <header>\n    <version>0.9</version>\n  </header>\n  <body>\n    <data_block>\n      <dt_assoc>\n        <item key=\"foo\">\n          <dt_assoc>\n            <item key=\"bar\">baz&amp;&lt;</item>\n          </dt_assoc>\n        </item>\n      </dt_assoc>\n    </data_block>\n  </body>\n</OPS_envelope>\n}
+    end
   end
 
   describe '.encode_data' do


### PR DESCRIPTION
With Nokogiri, some node content was not appropriately sanitized. For example, trying to encode `foo&<` would produce `foo&amp;` which has a missing `<`. This is caused by not using the right function when adding the content. We should be using `content=` rather than `<<`.