### PR TITLE
Support Ruby 3+

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,28 @@
+name: Ruby
+
+on: push
+
+jobs:
+  test:
+    name: "Rspec (on Ruby ${{ matrix.ruby }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head']
+
+    steps:
+    - name: Set up Ruby ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: gem install bundler && bundle install
+
+    - name: Run Rspec
+      run: bundle exec rspec spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opensrs (0.4.0)
+    opensrs (0.4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opensrs (0.3.8)
+    opensrs (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,4 +96,4 @@ DEPENDENCIES
   shoulda
 
 BUNDLED WITH
-   1.17.2
+   2.3.12

--- a/lib/opensrs/version.rb
+++ b/lib/opensrs/version.rb
@@ -1,3 +1,3 @@
 module OpenSRS
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/opensrs.gemspec
+++ b/opensrs.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Provides support to utilize the OpenSRS API with Ruby.'
   spec.homepage      = 'https://github.com/voxxit/opensrs'
   spec.license       = 'MIT'
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'

--- a/spec/opensrs/server_spec.rb
+++ b/spec/opensrs/server_spec.rb
@@ -119,7 +119,7 @@ describe OpenSRS::Server do
       proxy = URI('http://user:password@example.com:1234')
       server.proxy = proxy
 
-      Net::HTTP.should_receive(:new).with(anything, anything, proxy.host, proxy.port, proxy.user, proxy.password)
+      expect(Net::HTTP).to receive(:new).with(anything, anything, proxy.host, proxy.port, proxy.user, proxy.password)
 
       server.call({ some: 'data' })
     end


### PR DESCRIPTION
👋  @voxxit Hi there! Sorry about #49 & #50. Those were accidents. I did not realize Github would open the PR against the original repo vs my forked repo - which was my intention. 

I'm opening this to allow apps using this gem to migrate to Ruby 3+. 

Currently, the `gemspec` locks the required ruby version to `~> 2.5` whereas the README mentions supporting * Ruby **>= 2.5**. 

There are two problematic scenarios which a developer can encounter

1. A Ruby 3+ app upgrading the gem from `0.3.8` to `0.4.0`
2. A Ruby 2.x app using `0.4.0` and upgrading to Ruby 3+

Scenario 1:

```
## Running Ruby 3.1
$ ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]

## Truncated diff:
diff --git a/Gemfile b/Gemfile
--- a/Gemfile
+++ b/Gemfile
-gem "opensrs", "~> 0.3.8"
+gem "opensrs", "~> 0.4.0"

## Install dependencies
$ bundle install
...
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
  ...
    opensrs (~> 0.4.0) was resolved to 0.4.0, which depends on
      Ruby (~> 2.5)

    Ruby
```

Scenario 2:

```
## Ruby 2.x app
$ ruby -v
ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [arm64-darwin21]

## Using 0.4.0
$ cat Gemfile | grep opensrs
gem "opensrs", "~> 0.4.0"

$ cat Gemfile.lock | grep opensrs
    opensrs (0.4.0)
  opensrs (~> 0.4.0)

## Updated to Ruby 3+
$ ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]

## Install dependencies
$ bundle install
...
Your bundle is locked to opensrs (0.4.0) from rubygems repository https://rubygems.org/ or installed locally, but that version can no longer be found in that source. That means
the author of opensrs (0.4.0) has removed it. You'll need to update your bundle to a version other than opensrs (0.4.0) that hasn't been removed in order to install.
```

A work around for apps running Ruby 3+ that would like to use this gem is to downgrade the version of the gem to `0.3.8` which does not specify a required ruby version and is treated as `>= 0` (See [RubyGems page](https://rubygems.org/gems/opensrs/versions/0.3.8)).

Updating the `required_ruby_version` in the gemspec to `'>= 2.5'` resolves both scenarios when the latest version of the gem is installed.

As part of this PR I've also made a few minor fixes, which can be reverted:

1. Updated Bundler to resolve deprecation warnings on Ruby 3.1

```
$ ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]

$ bundle install
/Users/jloppert/.gem/ruby/3.1.2/gems/bundler-1.17.2/lib/bundler/shared_helpers.rb:29: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/jloppert/.gem/ruby/3.1.2/gems/bundler-1.17.2/lib/bundler/shared_helpers.rb:118: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/jloppert/.gem/ruby/3.1.2/gems/bundler-1.17.2/lib/bundler/shared_helpers.rb:35: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
/Users/jloppert/.gem/ruby/3.1.2/gems/bundler-1.17.2/lib/bundler/shared_helpers.rb:44: warning: Pathname#untaint is deprecated and will be removed in Ruby 3.2.
...
```

2. Updated Rspec syntax deprecation

```
$ rspec spec/
...
Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/jloppert/src/github.com/JLoppert/opensrs/spec/opensrs/server_spec.rb:122:in `block (3 levels) in <top (required)>'.
```

3. Added a Github Action to run the test suite against multiple ruby versions

This can be verified here: 

https://github.com/JLoppert/opensrs/runs/6195207427
